### PR TITLE
(Updates) Create df with gene symbols & summarised TPM and R Loop pileup 

### DIFF
--- a/TPM_RLoops_df.R
+++ b/TPM_RLoops_df.R
@@ -9,8 +9,6 @@ load("geneTPM_and_RLAnno.rda")
 
 # summarising then mapping transcripts to genes --------------------------------------------
 
-head(geneTPM)
-
 #put names into standard TXID format
 geneTPM$TXID <- gsub("\\..*","", geneTPM$Name) 
 
@@ -28,14 +26,13 @@ df <- as.data.frame(left_join(df, anno)) %>% dplyr::select(c(SYMBOL, TPM)) %>% g
 
 # R loop wrangling --------------------------------------------------------
 
-head(RLAnno)
-
+#create rloops df from example data using SYMBOL and pileup 
 rloops <- data.frame(SYMBOL = RLAnno$SYMBOL, RLOOP_PILEUP = RLAnno$pileup)
 
+#groupby SYMBOL & summarise, returning mean of pileup values linked to each symbol) 
 rloops <- rloops %>% group_by(SYMBOL) %>% summarise(RLoop_Pileup_Mean=mean(RLOOP_PILEUP)) 
 
+#merge rloops with df, creating df with symbol, tpm & pileup mean columns 
 df <- left_join(df, rloops)
 
-head(df)
 
-df2['TPM','ABCA2']


### PR DESCRIPTION
Based on meeting feedback, code now: 

- formats TXIDs 
- annotates TXIDs with SYMBOLs
- groups TPM by symbol, giving sum of TPM values associated with each SYMBOL
- groups R-Loop pileup by symbol, giving mean of R-Loop Pileup values associated with each SYMBOL
- creates dataframe with columns SYMBOL, TPM & R-Loop Pileup Mean from example data 

(also, the commit title of  "fix: summarise to transcript level before mapping to genes" is misleading sorry! The next commit title is much more accurate) 